### PR TITLE
Fixed params in get_tests method

### DIFF
--- a/lib/testingbot/api.rb
+++ b/lib/testingbot/api.rb
@@ -26,7 +26,7 @@ module TestingBot
     end
 
     def get_tests(offset = 0, count = 10)
-      get("/tests")
+      get("/tests?offset=#{offset}&count=#{count}")
     end
 
     def get_single_test(test_id)


### PR DESCRIPTION
Fixed a small bug in get_tests method (count & offset params were not called).
